### PR TITLE
Duplication for simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project serves as a very slim backend designed to work with Klarna on Deman
 
 The server itself is implemented in [Ruby](https://www.ruby-lang.org/en/) using [Sinatra](http://www.sinatrarb.com/). Even if you are not familiar with the language do not worry, as the code has been extensively documented. The file that contains the entirety of the server is [backend.rb](./backend.rb).
 
+The server logs all API requests it performs to the terminal, so you can see what's going on even without diving into the code.
+
 ## Integration with the Klarna on Demand API
 This sample backend interacts directly with Klarna's on Demand API, specifically for the purpose of authorizing and capturing orders. You can read more about the API in the [official documentation (coming soon)](http://developers.klarna.com).
 
@@ -39,7 +41,7 @@ which should result in output such as:
 [2015-01-07 13:04:14] INFO  WEBrick::HTTPServer#start: pid=37268 port=9292
 ```
 
-indicating the server is now listening at port 9292. Note that as stated by the launch message, all requests performed against Klarna's API will be logged to the console so that you may examine them.
+indicating the server is now listening at port 9292.
 
 ## License
 The sample backend is available under the Apache 2.0 license. See the [LICENSE](./LICENSE) file for more info.

--- a/backend.rb
+++ b/backend.rb
@@ -26,6 +26,7 @@ class Backend < Sinatra::Base
     'TCKT0001' => {
       name:     'Movie ticket - The Girl with the Dragon Tattoo',
       cost:     9900,
+      currency: 'SEK',
       tax_cost: 990
     }
   }
@@ -57,7 +58,7 @@ class Backend < Sinatra::Base
         name:             item[:name],
         order_amount:     item[:cost],
         order_tax_amount: item[:tax_cost],
-        currency:         'SEK',
+        currency:         item[:currency],
         capture:          false,
         origin_proof:     params[:origin_proof]
       }.to_json

--- a/backend.rb
+++ b/backend.rb
@@ -80,7 +80,7 @@ class Backend < Sinatra::Base
       # The purchase has been successfully captured, respond with 204
       status 204
     else
-      halt authorize_response.code, 'Failed to capture order'
+      halt capture_response.code, 'Failed to capture order'
     end
   end
 end

--- a/backend.rb
+++ b/backend.rb
@@ -62,7 +62,7 @@ class Backend < Sinatra::Base
     authorize_url = "https://inapp.playground.klarna.com/api/v1/users/#{params[:user_token]}/orders"
     authorize_response = HTTParty.post(authorize_url, authorize_request.merge(logging_options))
 
-    if (authorize_payment_response && authorize_payment_response.code == 201)
+    if authorize_response && authorize_response.code == 201
       # The purchase was authorized (and has essentially been created as a
       # resource available at the location specified in the authorization
       # requests's response). Capture it.
@@ -71,7 +71,7 @@ class Backend < Sinatra::Base
       halt authorize_payment_response.code, 'Failed to authorize purchase'
     end
 
-    if (capture_response && capture_response.code == 200)
+    if capture_response && capture_response.code == 200
       # The purchase has been successfully captured, respond with 204
       status 204
     else

--- a/backend.rb
+++ b/backend.rb
@@ -66,16 +66,21 @@ class Backend < Sinatra::Base
       # The purchase was authorized (and has essentially been created as a
       # resource available at the location specified in the authorization
       # requests's response). Capture it.
-      capture_response = HTTParty.post("#{authorize_payment_response}/capture", common_options)
+      capture_request = {
+        basic_auth: { username: API_KEY, password: API_SECRET },
+      }
+
+      capture_url = authorize_response + "/capture"
+      capture_response = HTTParty.post(capture_url, capture_request.merge(logging_options))
     else
-      halt authorize_payment_response.code, 'Failed to authorize purchase'
+      halt authorize_response.code, 'Failed to authorize purchase'
     end
 
     if capture_response && capture_response.code == 200
       # The purchase has been successfully captured, respond with 204
       status 204
     else
-      halt authorize_payment_response.code, 'Failed to capture order'
+      halt authorize_response.code, 'Failed to capture order'
     end
   end
 end


### PR DESCRIPTION
I'm dumping a few suggestions here, which you may proudly ignore. Here's the gist of what's going on:
- Moved `currency` to `CATALOG`, just so people don't get the impression that they need to invent that as part of the request.
- Changed `authorize_request_options` to `authorize_request`, which is more than just a name change - I separated the actual request from the meta-options (logging options)
- Removed `common_options`, they are just logging options now (really there is not much sense in keeping logging options and basic auth stuff together)
- Renamed `authorize_payment_response` to `authorize_response` for consistency.
- Created a `capture_request`, which is basically just basic auth stuff (duplicated). It makes sense to me because you really see what is being sent. Reuse isn't really effective here.
- Some cosmetic changes (parentheses, extra spaces, etc.)

Besides considering these changes, I advise you to make sure the bloody thing still works, because I haven't. hah!
